### PR TITLE
competition/leaderboard/:id endpoint

### DIFF
--- a/app/controllers/competitions_controller.rb
+++ b/app/controllers/competitions_controller.rb
@@ -1,2 +1,23 @@
 class CompetitionsController < ApplicationController
+    def leaderboard
+        competition = Competition.find(params[:id])
+        players = competition.users
+        workouts = competition.workouts
+        
+        playerPoints = {}
+        players.map do |player|
+            playerPoints[player.username] = {points: 0, user: player.username}
+        end
+        
+        workouts.each do |workout| 
+            user = workout.user.username
+            playerPoints[user][:points] += workout.points
+        end
+
+        result = playerPoints.values.sort_by{|h| -h[:points]}.each_with_index do |hash, index|
+            hash[:rank] = index + 1
+        end
+
+        render json: result
+    end
 end

--- a/app/controllers/competitions_controller.rb
+++ b/app/controllers/competitions_controller.rb
@@ -1,23 +1,7 @@
 class CompetitionsController < ApplicationController
     def leaderboard
         competition = Competition.find(params[:id])
-        players = competition.users
-        workouts = competition.workouts
-        
-        playerPoints = {}
-        players.map do |player|
-            playerPoints[player.username] = {points: 0, user: player.username}
-        end
-        
-        workouts.each do |workout| 
-            user = workout.user.username
-            playerPoints[user][:points] += workout.points
-        end
-
-        result = playerPoints.values.sort_by{|h| -h[:points]}.each_with_index do |hash, index|
-            hash[:rank] = index + 1
-        end
-
-        render json: result
+        participants = competition.participants.sort_by {|p| -p.user_total_points}
+        render json: participants
     end
 end

--- a/app/controllers/workouts_controller.rb
+++ b/app/controllers/workouts_controller.rb
@@ -7,6 +7,9 @@ class WorkoutsController < ApplicationController
     def create
         workout_points = calculate_points(workout_params)
         workout = Workout.create!(workout_params.merge(:points => workout_points))
+        participant = Participant.where(user_id: params[:user_id], competition_id: params[:competition_id])
+        total_points = participant[0].user_total_points == nil ? 0 : participant[0].user_total_points + workout_points
+        participant.update!(user_total_points: total_points)
         render json: workout, status: :created
     end
 

--- a/app/serializers/competition_serializer.rb
+++ b/app/serializers/competition_serializer.rb
@@ -1,3 +1,4 @@
 class CompetitionSerializer < ActiveModel::Serializer
   attributes :id, :name, :identifier, :public
+  has_many :users, through: :participants
 end

--- a/app/serializers/participant_serializer.rb
+++ b/app/serializers/participant_serializer.rb
@@ -1,5 +1,3 @@
 class ParticipantSerializer < ActiveModel::Serializer
-  attributes :id
-  has_one :user
-  has_one :competition
+  attributes :id, :username, :user_total_points
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   resources :participants
   resources :comments
   resources :workouts
-  resources :competitions
+  # resources :competitions, only: [:show]
   resources :users
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
@@ -11,5 +11,6 @@ Rails.application.routes.draw do
   # root "articles#index"
 
   post "/auth/login", to: "authentication#login"
+  get "/competition/leaderboard/:id", to: "competitions#leaderboard"
   
 end

--- a/db/migrate/20230316181135_add_columns_to_participants.rb
+++ b/db/migrate/20230316181135_add_columns_to_participants.rb
@@ -1,0 +1,6 @@
+class AddColumnsToParticipants < ActiveRecord::Migration[7.0]
+  def change
+    add_column :participants, :username, :string
+    add_column :participants, :user_total_points, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_14_162745) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_16_181135) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -36,6 +36,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_14_162745) do
     t.bigint "competition_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "username"
+    t.integer "user_total_points"
     t.index ["competition_id"], name: "index_participants_on_competition_id"
     t.index ["user_id"], name: "index_participants_on_user_id"
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -18,10 +18,10 @@
 
 # print "Seeding Participants..."
 
-# Participant.create(user_id: 1, competition_id: 2)
-# Participant.create(user_id: 2, competition_id: 2)
-# Participant.create(user_id: 3, competition_id: 2)
-# Participant.create(user_id: 4, competition_id: 2)
+Participant.create(user_id: 1, competition_id: 2, username: "chrisli", user_total_points: 180)
+Participant.create(user_id: 2, competition_id: 2, username: "coco", user_total_points: 405)
+Participant.create(user_id: 3, competition_id: 2, username: "dulatK", user_total_points: 1200)
+Participant.create(user_id: 4, competition_id: 2, username: "alexisT", user_total_points: 450)
 
 print "Seeing workouts..."
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -25,9 +25,9 @@
 
 print "Seeing workouts..."
 
-Workout.create(activity: "Walking", duration: 60, intensity: "M", date: "3/08/2023", calories: 789, avg_HR: 149, user_id: 1, competition_id: 2)
-Workout.create(activity: "Strength Training", duration: 60, intensity: "H", date: "3/08/2023", calories: 600, avg_HR: 140, user_id: 2, competition_id: 2)
-Workout.create(activity: "Cardio", duration: 75, intensity: "H", date: "3/07/2023", calories: 750, avg_HR: 140, user_id: 3, competition_id: 2)
-Workout.create(activity: "HIIT", duration: 60, intensity: "M", date: "3/08/2023", calories: 800, avg_HR: 145, user_id: 4, competition_id: 2)
+Workout.create(activity: "Walking", duration: 60, intensity: "M", date: "3/08/2023", calories: 789, avg_HR: 149, user_id: 1, competition_id: 2, points: 180)
+Workout.create(activity: "Strength Training", duration: 60, intensity: "H", date: "3/08/2023", calories: 600, avg_HR: 140, user_id: 2, competition_id: 2, points: 405)
+Workout.create(activity: "Cardio", duration: 75, intensity: "H", date: "3/07/2023", calories: 750, avg_HR: 140, user_id: 3, competition_id: 2, points: 1200)
+Workout.create(activity: "HIIT", duration: 60, intensity: "M", date: "3/08/2023", calories: 800, avg_HR: 145, user_id: 4, competition_id: 2, points: 450)
 
 print "Complete!"


### PR DESCRIPTION
added endpoint competition/leaderboard/:id where params[:id] is the id of the competition
route takes you to competitions_controller#leaderboard

logic for calculating leaderboard:
* find the competition using id
* extract the players and workouts
* map through players and store in a hash, each player in the following shape:
```
playerPoints = {
   user1: { points: 0, user: user1 }
   user2: { points: 0, user: user2 } 
  ... etc
}
```
* map through workouts, and increment the points of each user in the playerPoints hash
* convert playerPoints hash into an array, sort by points and add ranking using index

fetching to "/competition/leaderboard:id" should return json in the following format:

```
[
   {
      "points": 100,
      "user": "user1",
      "rank": 1
   },
   {
      "points": 90,
      "user": "user2",
      "rank": 2
   },
      {
      "points": 50,
      "user": "user3",
      "rank": 3
   }
   ...etc...
]
```